### PR TITLE
refactor: Button 컴포넌트에 링크 기능 추가 (#77)

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import Link from 'next/link';
 import LoadingDots from '../LoadingDots/LoadingDots';
 import { ButtonProps } from '../../types/Button.types';
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
+      href,
       variant = 'primary',
       size = 'md',
       loading = false,
@@ -38,6 +40,34 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     };
 
     const widthStyles = fullWidth ? 'w-full' : '';
+
+    if (href) {
+      const handleClick = (e: React.MouseEvent) => {
+        if (disabled || loading) {
+          e.preventDefault();
+          return;
+        }
+        props.onClick?.(e as any);
+      };
+      return (
+        <Link
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${widthStyles} ${className}`}
+          onClick={handleClick}
+          aria-disabled={disabled || loading}
+        >
+          {loading ? (
+            <span className="flex items-center justify-center gap-1">
+              {children}
+              {showLoadingDots && <LoadingDots />}
+            </span>
+          ) : (
+            <span className="flex items-center justify-center gap-1">{children}</span>
+          )}
+        </Link>
+      );
+    }
 
     return (
       <button

--- a/src/types/Button.types.ts
+++ b/src/types/Button.types.ts
@@ -53,4 +53,6 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * 버튼 내용
    */
   children: ReactNode;
+
+  href?: string; // 링크(페이지 이동 등)
 }


### PR DESCRIPTION
## **📌 PR 개요**

- 기존 `Button` 컴포넌트에 `href` props`를 전달하면 `Link`로써 동작하도록 수정

## **🔍 관련 이슈**
- Closes #77
- 
## **🔧 변경 유형**
- [x] ♻️ refactor (리팩토링)

## **✨ 변경 사항**

- `Button.types.ts`
    - `href?` props 추가
    - type : `string | null`
- `Button.tsx`
    - `href`값이 있을 경우, `<Link>` 컴포넌트를 렌더링하도록 함

## **✅ 체크리스트**

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## **📸 스크린샷 (선택)**

- 

## **🤝 기타 참고 사항**

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 버튼 컴포넌트가 href를 통해 링크처럼 동작하도록 개선되어, 기존 스타일과 레이아웃을 유지하면서 링크로 전환할 수 있습니다.
  * 비활성화 또는 로딩 상태일 때는 동작을 차단하고, 로딩 상태에서는 시각적 로딩 표시가 링크 내부에서도 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->