### PR TITLE
refactor: titletextinput 30자 제한

### DIFF
--- a/src/app/(route)/addboard/components/TitleTextInput.tsx
+++ b/src/app/(route)/addboard/components/TitleTextInput.tsx
@@ -14,7 +14,12 @@ const TitleTextInput = ({ beforeValue, onChange }: TitleTextInput) => {
   const [value, setValue] = useState(beforeValue);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
+    let newValue = e.target.value;
+
+    // 최대 길이 자르기 (한글 포함)
+    if (Array.from(newValue).length > MAX_LENGTH) {
+      newValue = Array.from(newValue).slice(0, MAX_LENGTH).join('');
+    }
     setValue(newValue);
     onChange(newValue);
   };


### PR DESCRIPTION
- #178 충돌 해결이 어려워 나눠서 올리는 pr입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
  * 제목 입력 필드의 최대 문자 길이 제한이 한글을 포함한 다국어 문자를 정확하게 처리하도록 개선되었습니다. 복합 문자도 올바르게 계산되어 입력 길이가 제대로 제한됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->