### PR TITLE
Refacor/#222 위키 생성 후, 이동하는 경로를 메인(/)에서 위키리스트(/wikilist)로 수정

### DIFF
--- a/src/app/(route)/wikicreate/page.tsx
+++ b/src/app/(route)/wikicreate/page.tsx
@@ -99,7 +99,7 @@ export default function WikiCreatePage() {
         updateUserProfile({ code: data.code });
         router.push(`/wiki/${data.code}`);
       } else {
-        router.push('/');
+        router.push('/wikilist');
       }
     } catch (error) {
       console.error('위키 생성 실패:', error);


### PR DESCRIPTION
EOM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 위키 생성 후 응답에 코드가 없을 때 리다이렉트 경로 개선. 이제 홈페이지가 아닌 위키 목록 페이지로 사용자를 안내합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->